### PR TITLE
Enhancements: Command-line option for "-r / --passive port-range", LIST, NLST, and CD, and robustness to bad input

### DIFF
--- a/bin/faetus-server
+++ b/bin/faetus-server
@@ -7,8 +7,9 @@ from socket import gethostbyname, gaierror
 
 from pyftpdlib import ftpserver
 
-from faetus.server import FaetusAuthorizer, FaetusFS
+from faetus.server import FaetusFTPHandler, FaetusAuthorizer, FaetusFS
 from faetus.constants import version, default_address, default_port
+
 
 
 def setup_log(log_file=None):
@@ -32,8 +33,14 @@ def main():
                       type="int",
                       dest="port",
                       default=default_port,
-                      help="Port to bind the server default: %d." %
-                      (default_port))
+                      help="Port to bind the server: %d" % (default_port))
+
+    parser.add_option('-r', '--range',
+                      type="str",
+                      dest="range",
+                      default="",
+                      help="Range to use for passive ports (min,max) inclusive: %d,%d"
+                        % (60000, 65000))
 
     parser.add_option('-b', '--bind-address',
                       type="str",
@@ -46,27 +53,34 @@ def main():
                       dest="log_file",
                       default=None,
                       help="Log File: Default stdout")
+
     (options, _) = parser.parse_args()
 
     setup_log(options.log_file)
 
-    ftp_handler = ftpserver.FTPHandler
-
+    ftp_handler = FaetusFTPHandler
     ftp_handler.banner = 'Faetus %s using %s' % \
         (version, ftp_handler.banner)
     ftp_handler.authorizer = FaetusAuthorizer()
     
     ftp_handler.abstracted_fs = FaetusFS
-    ftp_handler.passive_ports = range(60000, 65535)
     
+    # Port range must include both start and end to be valid.
+    range_spec = options.range.split(",")
+    if len(range_spec) >= 2:
+      (min_port, max_port) = (int(range_spec[0]), int(range_spec[1]))
+      ftp_handler.passive_ports = range(min_port, max_port)
+      ftpserver.log("Passive mode port range: %i-%i" % (min_port, max_port))
+
+    ftpd = ftpserver.FTPServer((options.bind_address,
+                                options.port),
+                               ftp_handler)
+
     try:
         ftp_handler.masquerade_address = gethostbyname(options.bind_address)
     except gaierror, (_, errmsg):
         sys.exit('Address error: %s' % errmsg)
 
-    ftpd = ftpserver.FTPServer((options.bind_address,
-                                options.port),
-                               ftp_handler)
     ftpd.serve_forever()
 
 

--- a/bin/faetus-server
+++ b/bin/faetus-server
@@ -10,7 +10,11 @@ from pyftpdlib import ftpserver
 from faetus.server import FaetusFTPHandler, FaetusAuthorizer, FaetusFS
 from faetus.constants import version, default_address, default_port
 
-
+def dict_from_string(string):
+		""" Transform a colon-separated pair into a dict."""
+		# Ugh. ''.split(":") is [''], not [] as it should be.
+		if (string): return dict([string.split(":")])
+		else: return dict()
 
 def setup_log(log_file=None):
     ''' Setup Logging '''
@@ -53,7 +57,20 @@ def main():
                       dest="log_file",
                       default=None,
                       help="Log File: Default stdout")
+					  
+    parser.add_option('-u', '--username-transform-map',
+                      type="str",
+                      dest="username_transform_map_str",
+                      default=None,
+                      help="mapping from ftp username to AWS_ACCESS_KEY_ID: username:AWS_ACCESS_KEY. Default: none.")
 
+    parser.add_option('-v', '--password-transform-map',
+                      type="str",
+                      dest="password_transform_map_str",
+                      default=None,
+                      help="mapping from ftp password to AWS_SECRET_ACCESS_KEY: password:AWS_SECRET_ACCESS_KEY.\n Default: none. WARNING: This is not secure against local user eavesdropping!")
+
+					  
     (options, _) = parser.parse_args()
 
     setup_log(options.log_file)
@@ -61,7 +78,13 @@ def main():
     ftp_handler = FaetusFTPHandler
     ftp_handler.banner = 'Faetus %s using %s' % \
         (version, ftp_handler.banner)
-    ftp_handler.authorizer = FaetusAuthorizer()
+    
+    username_transform_map = dict_from_string(options.username_transform_map_str)
+    password_transform_map = dict_from_string(options.password_transform_map_str)
+    
+    ftpserver.log("Using username map: %s " % (username_transform_map))
+	
+    ftp_handler.authorizer = FaetusAuthorizer(username_transform_map, password_transform_map)
     
     ftp_handler.abstracted_fs = FaetusFS
     

--- a/faetus/server.py
+++ b/faetus/server.py
@@ -11,80 +11,45 @@ from boto.exception import S3ResponseError, S3CreateError
 from boto.s3.key import Key
 from boto.s3.bucket import Bucket
 from boto.s3.bucketlistresultset import BucketListResultSet
-    
+
+# The path separator used for "virtual directories" in  the cloud system. ("/" for S3)
+# This is used for two purposes:
+# 1. To recover slashes that pyftpdlib (un)"helpfully" translated to os.sep
+# 2. To implement hierarchical keys in S3.
+cloud_sep = '/'
+
+# The path separator used by the FTP server.
+# Since the FTP server does not have a local filesystem, there little reason to use the OS separator.
+# pyftpdlib uses os.sep, though, so we must conform here
+ftp_sep = os.sep
+
+
+# Bit definitions: http://linux.about.com/library/cmd/blcmdl2_stat.htm
+FULL_CONTROL_MODE_FLAG = 0600
+DIR_MODE_FLAG = 040600
+        
+
+def asciify(string):
+    # Try to convert string to a legible format for non-Unicode clients.
+    try:
+        return string.encode('utf-8')
+    except:
+        return string
+            
 class FaetusFTPHandler(ftpserver.FTPHandler):
         
     def __init__(self, conn, server):
       super(FaetusFTPHandler, self).__init__(conn, server)
      
-    def ftp_NLST(self, path):
-      return self.ftp_LIST(path, mode='NLST')
-
-    def ftp_LIST(self, path, mode='LIST'):
-        """Return a list of files in the specified directory.
-        If mode='NLST', in a compact name-list form to the client.
-        """
-
-        # FIXME, is this enough? We need to avoid super's attempt to call
-        # "sort" on the resulting BucketListResultSet
-
-        try:
-          line = self.fs.fs2ftp(path)
-          list = []
-          if self.fs.isdir(path):
-                listing = self.fs.listdir(path)
-                # Convert iterator to list for FTP
-                if mode == 'NLST':
-                  for object in listing:
-                    list.append(object.name)
-                else:   
-                  if isinstance(listing, BucketListResultSet):
-                      formatted_listing = self.fs.format_list_objects(listing)
-                  else:
-                      formatted_listing = self.fs.format_list_buckets(listing)
-                  for text in formatted_listing:
-                      list.append(text)
-          else:
-                # list = [ os.path.basename(path) ]
-                for candidate in [path, self.fs._cwd + '/' + path]:
-                  if self.fs.isfile(candidate):
-                    _, bucket, obj = self.fs.parse_fspath(candidate)
-                    if mode == 'NLST':
-                      list.append(candidate)
-                    else:
-                      # This fails due to inconsistent time formatting:
-                      #  Line 376, in format_list_objects "%Y-%m-%dT%H:%M:%S")[0:6]).strftime("%b %d %H:%M")
-                      #  File "_strptime.py", line 454, in _strptime_time return _strptime(data_string, format)[0]
-                      #  File "_strptime.py", line 325, in _strptime (data_string, format))
-                      # ValueError: time data 'Tue, 08 Mar 2011 10:14:25 GM' does not match format '%Y-%m-%dT%H:%M:%S'
-                      
-                      # list = self.fs.format_list_objects([self.fs.open(candidate,'r').obj])
-
-                      # To unblock current work, just print the filename:
-                      list.append(candidate)
-
-
-                    break;
-
-          data = ''
-          if list:
-            data = ''.join(list) + '\r\n'
-          self.push_dtp_data(data, cmd="NLST")
-          return
-
-        except OSError, err:
-          self.respond('550 %s.' % ftpserver._strerror(err)) 
-          return
-
-
 
 class FaetusOperations(object):
-    '''Storing connection object'''
+    """Storing connection object."""
     def __init__(self):
         self.connection = None
         self.username = None
         
     def authenticate(self, username, password):
+        ''       
         self.username = username
         self.connection = S3Connection(username, password)
 
@@ -96,19 +61,46 @@ operations = FaetusOperations()
 
 
 class FaetusAuthorizer(ftpserver.DummyAuthorizer):
-    '''FTP server authorizer. Logs the users into Rackspace Cloud
-    Files and keeps track of them.
+    '''FTP server authorizer and credentials transformer. Logs the users into S3 and keeps track of them.
+ In order to provide some "weak" security for shared access to an S3 account,
+ transform maps are accepted. These transform maps are use by authenticate,
+ to replace the ftp credentials into S3 credentials.
+ username_transform_map is of the form {username : aws_access_key_id}
+ password_transform_map is of the form {password : aws_secret_access_key}
+ Note that due to the nature of S3, AWS_ACCESS_KEY_ID *cannot* be kept secret,
+ even if a username_transform_map is defined. A user who knows an FTP user name
+ and password can easily recover the AWS_ACCESS_KEY_ID (but not the AWS_SECRET_ACCESS_KEY)
     '''
     users = {}
+    
+    def __init__(self, username_transform_map=None,  password_transform_map=None):
+        super(FaetusAuthorizer, self).__init__()
+        self.username_transform_map = username_transform_map or {}
+        self.password_transform_map = password_transform_map or {}
 
+    def transform_username(self, username):
+        ftpserver.log("transforming username %s" % (username))
+        if (self.username_transform_map.has_key(username)):
+            username = self.username_transform_map[username]
+        ftpserver.log("transformed username to %s" % (username))
+        return username
+            
+    def transform_password(self, password):
+        if (self.password_transform_map.has_key(password)):
+            password = self.password_transform_map[password]
+        return password
+    
     def validate_authentication(self, username, password):
-        '''username: your amazon AWS_ACCESS_KEY_ID
-        password: your amazon AWS_SECRET_ACCESS_KEY
+        '''username: your amazon AWS_ACCESS_KEY_ID or a mapped username
+        password: your amazon AWS_SECRET_ACCESS_KEY or a mapped password
         '''
         try:
-            operations.authenticate(username, password)
+            s3_username = self.transform_username(username)
+            s3_password = self.transform_password(password)
+            operations.authenticate(s3_username, s3_password)
             return True
-        except:
+        except(Exception) as e:
+            ftpserver.logerror(e)
             return False
 
     def has_user(self, username):
@@ -121,7 +113,8 @@ class FaetusAuthorizer(ftpserver.DummyAuthorizer):
         return 'lrdw'
 
     def get_home_dir(self, username):
-        return os.sep + username
+        ftpserver.log("get_home_dir(%s(" % (username))
+        return ftp_sep + self.transform_username(username)
 
     def get_msg_login(self, username):
         return 'Welcome %s' % username
@@ -141,14 +134,14 @@ class FaetusFD(object):
         self.total_size = 0
         self.temp_file_path = None
         self.temp_file = None
-
+        ftpserver.log("Creating FaetusFD(%s,%s,%s,%s)" %(username, bucket, obj, mode))
+        
         if not all([username, bucket, obj]):
             self.closed = True
             raise IOError(1, 'Operation not permitted')
 
         try:
-            self.bucket = \
-                operations.connection.get_bucket(self.bucket)
+            self.bucket = operations.connection.get_bucket(self.bucket)
         except:
             raise IOError(2, 'No such file or directory')
 
@@ -175,14 +168,22 @@ class FaetusFD(object):
         if 'r' in self.mode:
             return
         self.temp_file.close()
-        self.obj.set_contents_from_filename(self.temp_file_path)
+        try: 
+            self.obj.set_contents_from_filename(self.temp_file_path)
+        except S3ResponseError as e:
+            # Avoid crashing when the "directory" vanished while we were processing it.
+            # This is actually due to a server error. It seems to happen after
+            # a "rm file" command incorrectly deletes an entire directory. (!!!)
+            ftpserver.logerror("Directory vanished! could not set contents from file %s " % (self.temp_file_path))
+            return
+
         self.obj.close()
         
         # clean up the temporary file
         os.remove(self.temp_file_path)
         self.temp_file_path = None
         self.temp_file = None
-    
+       
     def read(self, size=65536):
         return self.obj.read()
 
@@ -194,30 +195,37 @@ class FaetusFS(ftpserver.AbstractedFS):
     '''Amazon S3 File system emulation for FTP server.
     '''
 
+    # MAX  #objects to display in a bucket, to avoid getting swamped
+    # FIXME: implement "virtual directory" support, for keys with '/' in name.
+    MAX_OBJECTS = 1000
+                
     def __init__(self, root, cmd_channel): super(FaetusFS, self).__init__(root, cmd_channel)
 
     def get_all_buckets(self):
       try: 
-        return operations.connection.get_all_buckets()
+        return list(operations.connection.get_all_buckets())
       except S3ResponseError as e:
         raise OSError(1, "S3 error (probably bad credentials)" + str(e))
 
     def create_bucket(self, bucket):
       try: 
         return operations.connection.create_bucket(bucket)
-      except S3CreateError as e:
+      except (S3CreateError, S3ResponseError) as e:
         raise OSError(1, "S3 error (probably bucket name conflict)" + str(e))
 
     def parse_fspath(self, path):
         '''Returns a (username, site, filename) tuple. For shorter paths
-        replaces not provided values with empty strings.
+        replaces not-provided values with empty strings.
         '''
-        if not path.startswith(os.sep):
-            raise ValueError('parse_fspath: You have to provide a full path')
-        parts = path.split(os.sep)[1:]
+        ftpserver.log("parse_fspath(%s)" % (path))
+        if not path.startswith(ftp_sep):
+            raise ValueError('parse_fspath: You have to provide a full path, not %s'  % path)
+        parts = path.split(ftp_sep)[1:]
         if len(parts) > 3:
             # join extra 'directories' into key
-            parts = parts[0], parts[1], os.sep.join(parts[2:])
+            # Conveting os.sep (which was unfortunately introduced by pyftpdlib)
+            # to cloud_sep
+            parts = parts[0], parts[1], cloud_sep.join(parts[2:])
         while len(parts) < 3:
             parts.append('')
         return tuple(parts)
@@ -231,7 +239,7 @@ class FaetusFS(ftpserver.AbstractedFS):
             _, bucket, obj = self.parse_fspath(path)
 
             if not bucket:
-                if (self.isdir(path)):
+                if (self.isdir(path) and self.exists(path)):
                   self._cwd = self.fs2ftp(path)
                 else: 
                     raise OSError(550, 'Failed to change directory: Path is not a dir: ' + path)
@@ -247,6 +255,10 @@ class FaetusFS(ftpserver.AbstractedFS):
                     
             raise OSError(550, 'Path is not a dir: ' + obj)
 
+        ftpserver.logerror('Cannot chdir outside of root (%s) to %s' % (self.root, path));
+        raise OSError(1, 'Operation not permitted');
+                      
+
 
     def mkdir(self, path):
         try:
@@ -257,39 +269,83 @@ class FaetusFS(ftpserver.AbstractedFS):
             raise OSError(2, 'No such file or directory')
 
         self.create_bucket(bucket)
-
+                
     def listdir(self, path):
+        """List the content of a directory, as a list of strings."""            
+
+        try:
+            _, bucket_name, key_name = self.parse_fspath(path)
+        except(ValueError):
+            raise OSError(2, 'No such file or directory')
+        
+        if not bucket_name and not key_name:
+            buckets = self.get_all_buckets()
+            return map( (lambda bucket: asciify(bucket.name)), buckets)
+
+        if bucket_name and not key_name:
+            try:
+                bucket = operations.connection.get_bucket(bucket_name)
+                # BEWARE! Since S3 does not have native directories
+                # this bucket can have arbitrarily many elements.
+                # Do NOT convert it to a list!
+                # FIXME: implement conventional "virtual directory" support.
+                # List only the set of unique prefixes ("virtual directories")
+                # http://boto.s3.amazonaws.com/ref/s3.html
+                count = 0
+                objects_limited = []
+                for object in bucket.list(delimiter=cloud_sep):
+                    count = count + 1
+                    if count > self.MAX_OBJECTS:
+                        ftpserver.logerror("Too many items to list! Stopping at #%d" % MAX_OBJECTS)
+                        break
+                    objects_limited.append(object)
+                
+                return map( (lambda object: asciify(object.name)), objects_limited)
+            except:
+                raise OSError(2, 'No such file or directory')
+
+    
+    def get_list_dir(self, path):
+        """"Return an iterator object that yields a directory listing
+        in a form suitable for LIST command.
+        """
         try:
             _, bucket, obj = self.parse_fspath(path)
         except(ValueError):
             raise OSError(2, 'No such file or directory')
-
+        
         if not bucket and not obj:
-            return self.get_all_buckets()
+            buckets = self.get_all_buckets()
+            return self.list_buckets(buckets)
 
         if bucket and not obj:
             try:
-                cnt = operations.connection.get_bucket(bucket)
-                return cnt.list()
+                objects = operations.connection.get_bucket().list(delimiter=cloud_sep)
             except:
                 raise OSError(2, 'No such file or directory')
-        
+            return self.format_list_objects(objects)
+
+
 
     def rmdir(self, path):
         _, bucket, name = self.parse_fspath(path)
 
+        # If the user requests 'rmdir' of a file, refuse that.
+        # This is important to avoid falling through to delete an entire bucket!
         if name:
+            ftpserver.logerror("RMD requested on (non-drectory) file.")
             raise OSError(13, 'Operation not permitted')
 
-        try:
-            bucket = operations.connection.get_bucket(bucket)
-        except:
-            raise OSError(2, 'No such file or directory')
-
-        try:
-            operations.connection.delete_bucket(bucket)
-        except:
-            raise OSError(39, "Directory not empty: '%s'" % bucket)
+        else:
+            try:
+                bucket = operations.connection.get_bucket(bucket)
+            except:
+                raise OSError(2, 'No such file or directory')
+    
+            try:
+                operations.connection.delete_bucket(bucket)
+            except:
+                raise OSError(39, "Directory not empty: '%s'" % bucket)
 
     def remove(self, path):
         _, bucket, name = self.parse_fspath(path)
@@ -328,35 +384,61 @@ class FaetusFS(ftpserver.AbstractedFS):
 
     def lexists(self, path):
         try:
-            _, bucket, obj = self.parse_fspath(path)
+            _, bucket_name, key_name = self.parse_fspath(path)
         except(ValueError):
             raise OSError(2, 'No such file or directory')
 
-        if not bucket and not obj:
-            buckets = self.get_all_buckets()
-            return bucket in buckets
-
-        if bucket and not obj:
+        if not bucket_name and not key_name:
+            return True # root
+            
+        if bucket_name and not key_name:
             try:
-                cnt = operations.connection.get_bucket(bucket)
-                objects = cnt.list()
+                bucket = operations.connection.get_bucket(bucket_name)
+                objects = bucket.list()
             except:
                 raise OSError(2, 'No such file or directory')
             return obj in objects
 
-    def isfile(self, path):
-        _, bucket, name = self.parse_fspath(path)
-        return name
+        if bucket_name and key_name:
+            bucket = operations.connection.get_bucket(bucket_name)
+            return not (not bucket.get_key(key_name))
+
 
     def stat(self, path):
-        _, bucket, name = self.parse_fspath(path)
-        if not name:
-            raise OSError(40, 'unsupported')
+
+        st_mode = FULL_CONTROL_MODE_FLAG
+        _, bucket_name, key_name = self.parse_fspath(path)
+
+        #Hack together a stat result
+        
+        st_size = 0
+        st_mtime = datetime.datetime(  *time.strptime("1970-01-01",  "%Y-%m-%d")[0:6])
+
         try:
-            bucket = operations.connection.get_bucket(bucket)
-            obj = bucket.get_key(name)
-            return os.stat_result((666, 0L, 0L, 0, 0, 0, obj.size, 0, 0, 0))
-        except:
+            if not key_name: # Bucket
+                # Return a part-bogus stat with the data we do have.
+                st_mode = st_mode | DIR_MODE_FLAG
+    
+                return stat_result
+            else: # Key
+                bucket = operations.connection.get_bucket(bucket_name)
+                if (key_name[-1] == cloud_sep): # Virtual directory for hierarchical key.
+                    st_mode = st_mode | DIR_MODE_FLAG
+                else:
+                    obj = bucket.get_key(key_name)
+                    # Workaround os.sep crap.
+                    if obj is None:
+                        obj = bucket.get_key(key_name.replace(cloud_sep, os.sep))
+                    if obj is None:
+                         ftpserver.logerror("Cannot find object for path %s , key %s in bucket %s " % (path, key_name, bucket_name))
+                         raise OSError(2, 'No such file or directory')
+                    st_size = obj.size
+                   
+            return os.stat_result([st_mode, 0, 0, 0, 0, 0, st_size, 0, 0, 0])  #FIXME more stats (mtime)
+
+        
+        except Exception as e:
+            ftpserver.logerror("Failed stat(%s) %s %s: %s " % (path, bucket_name, key_name, e))
             raise OSError(2, 'No such file or directory')
 
     exists = lexists
@@ -365,42 +447,26 @@ class FaetusFS(ftpserver.AbstractedFS):
     def validpath(self, path):
         return True
 
-    def get_list_dir(self, path):
-        try:
-            _, bucket, obj = self.parse_fspath(path)
-        except(ValueError):
-            raise OSError(2, 'No such file or directory')
-        
-        if not bucket and not obj:
-            buckets = self.get_all_buckets()
-            return self.format_list_buckets(buckets)
-
-        if bucket and not obj:
-            try:
-                cnt = operations.connection.get_bucket(bucket)
-                objects = cnt.list()
-            except:
-                raise OSError(2, 'No such file or directory')
-            return self.format_list_objects(objects)
-
-
     def format_list_objects(self, items):
         for item in items:
+            if item.name[-1] == cloud_sep:
+                dir_flag = 'd'
+            else:
+                dir_flag = '-'
             ts = datetime.datetime(
                 *time.strptime(
                     item.last_modified[:item.last_modified.find('.')],
                     "%Y-%m-%dT%H:%M:%S")[0:6]).strftime("%b %d %H:%M")
 
-            yield '-rw-rw-rw-   1 %s   group  %8s %s %s\r\n' % \
-                (operations.username, item.size, ts, item.name)
+            yield '%srw------   1 %s   group  %8s %s %s\r\n' % \
+                (dir_flag, operations.username, item.size, ts, item.name)
 
     def format_list_buckets(self, buckets):
         for bucket in buckets:
-            yield 'drwxrwxrwx   1 %s   group  %8s Jan 01 00:00 %s\r\n' % \
-                (operations.username, 0, bucket.name)
+            name = asciify(bucket.name)
+            yield ('drwx------   1 %s   group  %8s Jan 01 00:00 %s\r\n' % \
+                   (operations.username, 0, name))
+            
 
     def get_stat_dir(self, *kargs, **kwargs):
-        raise OSError(40, 'unsupported')
-
-    def format_mlsx(self, *kargs, **kwargs):
         raise OSError(40, 'unsupported')

--- a/tests/test_faetus.py
+++ b/tests/test_faetus.py
@@ -11,6 +11,7 @@ from faetus.constants import default_address, default_port
 class FaetusTest(unittest.TestCase):
     ''' Faetus main test '''
 
+
     def setUp(self):
         if not all(['AWS_ACCESS_KEY_ID' in os.environ,
                     'AWS_SECRET_ACCESS_KEY' in os.environ]):
@@ -19,13 +20,14 @@ class FaetusTest(unittest.TestCase):
 
         self.username = os.environ['AWS_ACCESS_KEY_ID']
         self.password = os.environ['AWS_SECRET_ACCESS_KEY']
+        self.test_bucket_name = "/faetus_testing-" + self.username.lower()
         self.cnx = ftplib.FTP()
         self.cnx.host = default_address
         self.cnx.port = default_port
         self.cnx.connect()
         self.cnx.login(self.username, self.password)
-        self.cnx.mkd("/faetus_testing")
-        self.cnx.cwd("/faetus_testing")
+        self.cnx.mkd(self.test_bucket_name)
+        self.cnx.cwd(self.test_bucket_name)
 
     def test_mkdir_chdir_rmdir(self):
         ''' mkdir/chdir/rmdir directory '''
@@ -66,7 +68,7 @@ class FaetusTest(unittest.TestCase):
                             StringIO.StringIO("Hello Moto"))
         #self.assertRaises does not seems to work no idea why but that works
         try:
-            self.cnx.cwd("/faetus_testing/testfile.txt")
+            self.cnx.cwd(self.test_bucket_name + "/testfile.txt")
         except(ftplib.error_perm):
             pass
         else:
@@ -87,7 +89,7 @@ class FaetusTest(unittest.TestCase):
         self.cnx.delete("testfile.txt")
 
     def tearDown(self):
-        self.cnx.rmd("/faetus_testing")
+        self.cnx.rmd(self.test_bucket_name)
         self.cnx.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Enhancements:
1. All tests/faetus_server now pass. (I think this is news.)
2. LIST, NLST, and CD mostly work, and (almost?) never crash connection.
3. Invalid input (bogus file names) is gracefully ignored, instead of
   dropping connection.
4. Add support for Command-line option to specify the passive port range "-r / --passive port-range min,max", LIST
   Known bugs:
5. LIST on a file behaves like NLST, echoing back name only without stats. 
